### PR TITLE
Add relocation relaxation

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1249,6 +1249,10 @@ Finally the bit-field of X specified in the table (those bits of X picked out by
 
 For "``MOVW``" type relocations it is the assembler’s responsibility to encode the hw bits (bits 21 and 22) to indicate the bits in the target value that the immediate field represents.
 
+Relocation relaxation
+^^^^^^^^^^^^^^^^^^^^^
+
+Linkers may perform relocation relaxations to optimize instructions affected by relocation. Relocations that result in addition with zero may emit a faster register move or nop instead. The relocations ``R_<CLS>_ADR_GOT_PAGE`` and ``R_<CLS>_LD64_GOT_LO12_NC`` may be relaxed if all such relocations for a symbol are consecutive pairs, and both relocations write the same register. In this case each pair is independent and can be safely relaxed. If the symbol is not pre-emptable, the addend is zero and the destination is within ADRP range, the relocations relax to ``R_<CLS>_ADR_PREL_PG_HI21`` and ``R_<CLS>_LDST64_ABS_LO12_NC``.
 
 Proxy-generating relocations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add initial description of relocation relaxations. Make it clear that linkers may optimize existing relocations (or pairs of relocations) to improve code quality. A simple relaxation is replacing the common case of addition with zero with a move or nop. A more complex one is removing unnecessary GOT indirections from non pre-emptable symbols:

adrp x0, :got: symbol
ldr    x0, [x0, :got_lo12: symbol]

and change into:

adrp x0, symbol
add  x0, x0, :lo12: symbol

This works if these relocations are grouped in pairs and both instructions in each pair read/write the same register.